### PR TITLE
Remove hard-coded python version

### DIFF
--- a/src/python/poetry.ts
+++ b/src/python/poetry.ts
@@ -33,9 +33,6 @@ export class Poetry extends Component implements IPythonDeps, IPythonEnv, IPytho
     this.project.tasks.addEnvironment('VIRTUAL_ENV', '$(poetry env info -p)');
     this.project.tasks.addEnvironment('PATH', '$(echo $(poetry env info -p)/bin:$PATH)');
 
-    // declare the python versions for which the package is compatible
-    this.addDependency('python@^3.6');
-
     this.packageTask = project.addTask('package', {
       description: 'Creates source archive and wheel for distribution.',
       exec: 'poetry build',


### PR DESCRIPTION
* The Python version is currently hard-coded to ^3.6
* The Python version has a knock-on effect to the versions of other packages
  that are retrieved by poetry. Some projects may require more recent versions
  of Python.
* Remove the auto-addition of the Python dependency in favour of specifying
  it explicitly in the 'deps' section of each project.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.